### PR TITLE
Async error tracking

### DIFF
--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -39,6 +39,8 @@ type
 
   FutureVar*[T] = distinct Future[T]
 
+  FutureUntracked*[T] = Future[T]
+
   FutureError* = object of Defect
     cause*: FutureBase
 
@@ -136,6 +138,9 @@ proc newFutureVar*[T](fromProc = "unspecified"): owned(FutureVar[T]) =
   result = typeof(result)(fo)
   when isFutureLoggingEnabled: logFutureStart(Future[T](result))
 
+proc newFutureUntracked*[T](fromProc = "unspecified"): FutureUntracked[T] =
+  newFuture[T](fromProc)
+
 proc clean*[T](future: FutureVar[T]) =
   ## Resets the `finished` status of `future`.
   Future[T](future).finished = false
@@ -162,11 +167,13 @@ proc checkFinished[T](future: Future[T]) =
       err.cause = future
       raise err
 
-proc call(callbacks: var CallbackList) =
+proc call(callbacks: var CallbackList) {.raises: [].} =
   var current = callbacks
   while true:
     if not current.function.isNil:
-      callSoon(current.function)
+      # XXX make callbacks {.raise: [].}
+      {.cast(raises: []).}:
+        callSoon(current.function)
 
     if current.next.isNil:
       break

--- a/lib/pure/asyncfutures.nim
+++ b/lib/pure/asyncfutures.nim
@@ -7,7 +7,7 @@
 #    distribution, for details about the copyright.
 #
 
-import std/[os, sets, tables, strutils, times, heapqueue, options, deques, cstrutils, typetraits]
+import std/[os, macros, sets, tables, strutils, times, heapqueue, options, deques, cstrutils, typetraits]
 
 import system/stacktraces
 
@@ -40,6 +40,8 @@ type
   FutureVar*[T] = distinct Future[T]
 
   FutureUntracked*[T] = Future[T]
+
+  FutureTracked*[T, E] = distinct Future[T]
 
   FutureError* = object of Defect
     cause*: FutureBase
@@ -390,6 +392,28 @@ proc read*[T](future: Future[T] | FutureVar[T]): lent T =
 
 proc read*(future: Future[void] | FutureVar[void]) =
   readImpl(future, void)
+
+macro readTrackedImpl(future: FutureTracked): untyped =
+  # XXX refactor readImpl
+  let t = getTypeInst(future)[1]
+  let e = getTypeInst(future)[2]
+  let types = getType(e)
+  var raisesList = newNimNode(nnkBracket)
+  for r in types[1..^1]:
+    raisesList.add(r)
+  #echo repr raisesList
+  #echo repr t
+  let theCast = quote do:
+    cast(raises: `raisesList`)
+  quote do:
+    {.`theCast`.}:
+      readImpl(`future`, `t`)
+
+proc read*[T, E](future: FutureTracked[T, E]): lent T =
+  readTrackedImpl(future)
+
+proc read*[E](future: FutureTracked[void, E]) =
+  readTrackedImpl(future)
 
 proc readError*[T](future: Future[T]): ref Exception =
   ## Retrieves the exception stored in `future`.

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -335,7 +335,7 @@ proc asyncSingleProc(prc: NimNode): NimNode =
   # Add discardable pragma.
   if returnType.kind == nnkEmpty:
     # xxx consider removing `owned`? it's inconsistent with non-void case
-    result.params[0] = quote do: owned(Future[void])
+    result.params[0] = quote do: owned(FutureUntracked[void])
 
   # based on the yglukhov's patch to chronos: https://github.com/status-im/nim-chronos/pull/47
   if procBody.kind != nnkEmpty:
@@ -422,7 +422,7 @@ macro trackFuture*(prc: typed): untyped =
   let retTyp = procImpl.params[0]
   doAssert retTyp.kind == nnkBracketExpr
   let fut = repr(retTyp[0])
-  doAssert fut == "Future", fut
+  doAssert fut == "FutureUntracked", fut
   let baseTyp = retTyp[1]
   let raisesList = getRaisesList(prc[0])
   let exTyp = if raisesList.len == 0:

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -49,9 +49,10 @@ template createCb(futTyp, strName, identName, futureVarCompletions: untyped) =
     except:
       futureVarCompletions
       if fut.finished:
-        # Take a look at tasyncexceptions for the bug which this fixes.
-        # That test explains it better than I can here.
-        raise
+        {.cast(raises: []).}:
+          # Take a look at tasyncexceptions for the bug which this fixes.
+          # That test explains it better than I can here.
+          raise
       else:
         fut.fail(getCurrentException())
   {.pop.}
@@ -158,6 +159,9 @@ proc verifyReturnType(typeName: string, node: NimNode = nil) =
     error("Expected return type of 'Future' got '$1'" %
           typeName, node)
 
+template isUntracked[T](f: Future[T]): bool =
+  getTypeInst(getType(typeof f))[1][0] == getTypeInst(getType(FutureUntracked[T]))[1][0]
+
 template await*(f: typed): untyped {.used.} =
   static:
     error "await expects Future[T], got " & $typeof(f)
@@ -171,7 +175,11 @@ template await*[T](f: Future[T]): auto {.used.} =
     var internalTmpFuture: FutureBase = f
     yield internalTmpFuture
     {.line: instantiationInfo(fullPaths = true).}:
-      (cast[typeof(f)](internalTmpFuture)).read()
+      when f.isUntracked:
+        {.cast(raises: []).}:
+          (cast[typeof(f)](internalTmpFuture)).read()
+      else:
+        (cast[typeof(f)](internalTmpFuture)).read()
   else:
     macro errorAsync(futureError: Future[T]) =
       error(
@@ -303,7 +311,7 @@ proc asyncSingleProc(prc: NimNode): NimNode =
       newVarStmt(retFutureSym,
         newCall(
           newNimNode(nnkBracketExpr, prc.body).add(
-            newIdentNode("newFuture"),
+            newIdentNode("newFutureUntracked"),
             subRetType),
         newLit(prcName)))) # Get type from return type of this proc
 

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -416,13 +416,13 @@ macro multisync*(prc: untyped): untyped =
 macro trackFuture*(prc: typed): untyped =
   # XXX error instead of asserts
   #echo repr getRaisesList(prc[0])
-  assert prc.kind == nnkCall
+  #assert prc.kind == nnkCall
   let procImpl = getTypeImpl(prc[0])
-  assert procImpl.kind == nnkProcTy
+  #assert procImpl.kind == nnkProcTy
   let retTyp = procImpl.params[0]
-  assert retTyp.kind == nnkBracketExpr
+  #assert retTyp.kind == nnkBracketExpr
   let fut = repr(retTyp[0])
-  assert fut == "FutureUntracked", fut
+  #assert fut == "FutureUntracked", fut
   let baseTyp = retTyp[1]
   let raisesList = getRaisesList(prc[0])
   let exTyp = if raisesList.len == 0:

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -9,7 +9,7 @@
 
 ## Implements the `async` and `multisync` macros for `asyncdispatch`.
 
-import std/[macros, strutils, asyncfutures]
+import std/[macros, strutils, asyncfutures, effecttraits]
 
 type
   Context = ref object
@@ -177,9 +177,9 @@ template await*[T](f: Future[T]): auto {.used.} =
     {.line: instantiationInfo(fullPaths = true).}:
       when f.isUntracked:
         {.cast(raises: []).}:
-          (cast[typeof(f)](internalTmpFuture)).read()
+          cast[typeof(f)](internalTmpFuture).read()
       else:
-        (cast[typeof(f)](internalTmpFuture)).read()
+        cast[typeof(f)](internalTmpFuture).read()
   else:
     macro errorAsync(futureError: Future[T]) =
       error(
@@ -187,6 +187,16 @@ template await*[T](f: Future[T]): auto {.used.} =
         "'waitFor' when calling an 'async' proc in a non-async scope instead",
         futureError)
     errorAsync(f)
+
+template await*[T, E](f: FutureTracked[T, E]): untyped =
+  template yieldFuture = yield FutureBase()
+  when compiles(yieldFuture):
+    var internalTmpFuture: FutureBase = Future[T](f)
+    yield internalTmpFuture
+    {.line: instantiationInfo(fullPaths = true).}:
+      cast[typeof(f)](internalTmpFuture).read()
+  else:
+    {.error: "await is only available within {.async.}".}
 
 proc asyncSingleProc(prc: NimNode): NimNode =
   ## This macro transforms a single procedure into a closure iterator.
@@ -402,3 +412,24 @@ macro multisync*(prc: untyped): untyped =
   result = newStmtList()
   result.add(asyncSingleProc(asyncPrc))
   result.add(sync)
+
+macro trackFuture*(prc: typed): untyped =
+  # XXX error instead of asserts
+  #echo repr getRaisesList(prc[0])
+  doAssert prc.kind == nnkCall
+  let procImpl = getTypeImpl(prc[0])
+  doAssert procImpl.kind == nnkProcTy
+  let retTyp = procImpl.params[0]
+  doAssert retTyp.kind == nnkBracketExpr
+  let fut = repr(retTyp[0])
+  doAssert fut == "Future", fut
+  let baseTyp = retTyp[1]
+  let raisesList = getRaisesList(prc[0])
+  let exTyp = if raisesList.len == 0:
+    newIdentNode("void")
+  else:
+    newNimNode(nnkTupleConstr)
+  for r in raisesList:
+    exTyp.add r
+  result = quote do:
+    FutureTracked[`baseTyp`, `exTyp`](`prc`)

--- a/lib/pure/asyncmacro.nim
+++ b/lib/pure/asyncmacro.nim
@@ -416,13 +416,13 @@ macro multisync*(prc: untyped): untyped =
 macro trackFuture*(prc: typed): untyped =
   # XXX error instead of asserts
   #echo repr getRaisesList(prc[0])
-  doAssert prc.kind == nnkCall
+  assert prc.kind == nnkCall
   let procImpl = getTypeImpl(prc[0])
-  doAssert procImpl.kind == nnkProcTy
+  assert procImpl.kind == nnkProcTy
   let retTyp = procImpl.params[0]
-  doAssert retTyp.kind == nnkBracketExpr
+  assert retTyp.kind == nnkBracketExpr
   let fut = repr(retTyp[0])
-  doAssert fut == "FutureUntracked", fut
+  assert fut == "FutureUntracked", fut
   let baseTyp = retTyp[1]
   let raisesList = getRaisesList(prc[0])
   let exTyp = if raisesList.len == 0:

--- a/tests/async/tasync_error_tracking.nim
+++ b/tests/async/tasync_error_tracking.nim
@@ -27,3 +27,13 @@ block:
     await bar(fooFut)
 
   waitFor main()
+
+block:
+  template good =
+    proc foo() {.async, raises: [MyError].} =
+      err(false)
+  template missingRaise =
+    proc foo() {.async, raises: [].} =
+      err(false)
+  doAssert compiles(good())
+  doAssert not compiles(missingRaise())

--- a/tests/async/tasync_error_tracking.nim
+++ b/tests/async/tasync_error_tracking.nim
@@ -2,12 +2,13 @@ import std/asyncdispatch
 
 type MyError = object of ValueError
 
-proc err =
-  raise newException(MyError, "myerr")
+proc err(throw: bool) =
+  if throw:
+    raise newException(MyError, "myerr")
 
 block:
   proc foo() {.async, raises: [MyError].} =
-    err()
+    err(false)
 
   proc main {.async.} =
     await foo()
@@ -16,7 +17,7 @@ block:
 
 block:
   proc foo() {.async, raises: [MyError].} =
-    err()
+    err(false)
 
   proc bar(fut: FutureTracked[void, (MyError,)]) {.async, raises: [MyError].} =
     await fut

--- a/tests/async/tasync_error_tracking.nim
+++ b/tests/async/tasync_error_tracking.nim
@@ -10,7 +10,7 @@ block:
   proc foo() {.async, raises: [MyError].} =
     err(false)
 
-  proc main {.async.} =
+  proc main {.async, raises: [MyError].} =
     await foo()
 
   waitFor main()
@@ -22,7 +22,7 @@ block:
   proc bar(fut: FutureTracked[void, (MyError,)]) {.async, raises: [MyError].} =
     await fut
 
-  proc main {.async.} =
+  proc main {.async, raises: [MyError].} =
     let fooFut = trackFuture foo()
     await bar(fooFut)
 

--- a/tests/async/tasync_error_tracking.nim
+++ b/tests/async/tasync_error_tracking.nim
@@ -1,0 +1,15 @@
+import std/asyncdispatch
+
+block:
+  type MyError* = object of ValueError
+
+  proc foo() {.async, raises: [MyError].} =
+    try:
+      echo "foo"
+    except ValueError as err:
+      raise newException(MyError, "myerr")
+
+  proc main {.async.} =
+    await foo()
+
+  waitFor main()

--- a/tests/async/tasync_error_tracking.nim
+++ b/tests/async/tasync_error_tracking.nim
@@ -1,15 +1,28 @@
 import std/asyncdispatch
 
-block:
-  type MyError* = object of ValueError
+type MyError = object of ValueError
 
+proc err =
+  raise newException(MyError, "myerr")
+
+block:
   proc foo() {.async, raises: [MyError].} =
-    try:
-      echo "foo"
-    except ValueError as err:
-      raise newException(MyError, "myerr")
+    err()
 
   proc main {.async.} =
     await foo()
+
+  waitFor main()
+
+block:
+  proc foo() {.async, raises: [MyError].} =
+    err()
+
+  proc bar(fut: FutureTracked[void, (MyError,)]) {.async, raises: [MyError].} =
+    await fut
+
+  proc main {.async.} =
+    let fooFut = trackFuture foo()
+    await bar(fooFut)
 
   waitFor main()

--- a/tests/async/tasync_error_tracking.nim
+++ b/tests/async/tasync_error_tracking.nim
@@ -7,6 +7,18 @@ proc err(throw: bool) =
     raise newException(MyError, "myerr")
 
 block:
+  proc bar() {.async.} =
+    err(false)
+  
+  proc foo() {.async.} =
+    await bar()
+
+  proc main {.async, raises: [MyError].} =
+    await foo()
+
+  waitFor main()
+
+block:
   proc foo() {.async, raises: [MyError].} =
     err(false)
 


### PR DESCRIPTION
Somewhat inspired in [chronos](https://github.com/status-im/nim-chronos/pull/251), but kinda the opposite.

Goal:

- Make async raises work exactly the same as non-async code.
- Callbacks must not raise for this to be sane. Albeit, I think code that passes callbacks that raise is broken anyway. It's possible to make this backward compatible, I think. Just deprecate the proc that takes a cb without raises: [], and cast it to untrack raises.
- Provide a way to pass error typed Futures around. There must be a way to get the error typed future of an async call.
- Backward compatible

Todo:

- tests
- fix for non-void Future returns, so it returns FutureUntracked
- make all, and, or not raise Exception
- make fail for tracked exceptions only allow listed errors
- fix introduced XXX
- This issue https://github.com/nim-lang/Nim/issues/22936 needs to be fixed to be able to make FutureUntracked an object instead of an alias. But it seems alias works fine so far.
- check all nimble packages using async compile

PR upstream once it looks like this is even possible.
